### PR TITLE
Read the OpenAI API key from environment variable OPENAI_API_KEY

### DIFF
--- a/o1-eng.py
+++ b/o1-eng.py
@@ -17,7 +17,7 @@ import re
 
 MODEL = "o1-mini"
 # Initialize OpenAI client
-client = OpenAI(api_key="YOUR KEY")
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
 CREATE_SYSTEM_PROMPT = """You are an advanced o1 engineer designed to create files and folders based on user instructions. Your primary objective is to generate the content of the files to be created as code blocks. Each code block should specify whether it's a file or folder, along with its path.


### PR DESCRIPTION
I think it is much better user experience if by default the "standard" environment variable OPENAI_API_KEY is checked for the OpenAI API key.